### PR TITLE
Fixed issue with data load into database in case of flat file.

### DIFF
--- a/ETLBox/src/Definitions/Database/TableData.cs
+++ b/ETLBox/src/Definitions/Database/TableData.cs
@@ -87,7 +87,7 @@ namespace ALE.ETLBox {
             throw new NotImplementedException();
         }
         public string GetString(int i) => Convert.ToString(CurrentRow[ShiftIndexAroundIDColumn(i)]);
-        public object GetValue(int i) => CurrentRow[ShiftIndexAroundIDColumn(i)];
+        public object GetValue(int i) => CurrentRow.Length > ShiftIndexAroundIDColumn(i) ? CurrentRow[ShiftIndexAroundIDColumn(i)] : (object)null;
 
         int ShiftIndexAroundIDColumn(int i) {            
             if (IDColumnIndex != null) {                


### PR DESCRIPTION
When using a flat file for ETL getting the below error 
Unhandled Exception: System.AggregateException: One or more errors occurred. (Index was outside the bounds of the array.) ---> System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at ALE.ETLBox.TableData`1.GetValue(Int32 i) in C:\Users\nallanmu\source\repos\OcelotApiGateway\etlbox-master\ETLBox\src\Definitions\Database\TableData.cs:line 90
   at System.Data.SqlClient.SqlBulkCopy.GetValueFromSourceRow(Int32 destRowIndex, Boolean& isSqlType, Boolean& isDataFeed, Boolean& isNull)
   at System.Data.SqlClient.SqlBulkCopy.ReadWriteColumnValueAsync(Int32 col)
   at System.Data.SqlClient.SqlBulkCopy.CopyColumnsAsync(Int32 col, TaskCompletionSource`1 source)
   at System.Data.SqlClient.SqlBulkCopy.CopyRowsAsync(Int32 rowsSoFar, Int32 totalRows, CancellationToken cts, TaskCompletionSource`1 source)
   at System.Data.SqlClient.SqlBulkCopy.CopyBatchesAsyncContinued(BulkCopySimpleResultSet internalResults, String updateBulkCommandText, CancellationToken cts, TaskCompletionSource`1 source)
   at System.Data.SqlClient.SqlBulkCopy.CopyBatchesAsync(BulkCopySimpleResultSet internalResults, String updateBulkCommandText, CancellationToken cts, TaskCompletionSource`1 source)
   at System.Data.SqlClient.SqlBulkCopy.WriteToServerInternalRestContinuedAsync(BulkCopySimpleResultSet internalResults, CancellationToken cts, TaskCompletionSource`1 source)
   at System.Data.SqlClient.SqlBulkCopy.WriteToServerInternalRestAsync(CancellationToken cts, TaskCompletionSource`1 source)
   at System.Data.SqlClient.SqlBulkCopy.WriteToServerInternalAsync(CancellationToken ctoken)
   at System.Data.SqlClient.SqlBulkCopy.WriteRowSourceToServerAsync(Int32 columnCount, CancellationToken ctoken)
   at System.Data.SqlClient.SqlBulkCopy.WriteToServer(IDataReader reader)
   at ALE.ETLBox.ConnectionManager.SqlConnectionManager.BulkInsert(ITableData data, String tableName) in C:\Users\nallanmu\source\repos\OcelotApiGateway\etlbox-master\ETLBox\src\Toolbox\ConnectionManager\SqlConnectionManager.cs:line 25
   at ALE.ETLBox.ControlFlow.DbTask.BulkInsert(ITableData data, String tableName) in C:\Users\nallanmu\source\repos\OcelotApiGateway\etlbox-master\ETLBox\src\Definitions\Tasks\DbTask.cs:line 173
   at ALE.ETLBox.DataFlow.DBDestination`1.WriteBatch(TInput[] data) in C:\Users\nallanmu\source\repos\OcelotApiGateway\etlbox-master\ETLBox\src\Toolbox\DataFlow\DBDestination.cs:line 89
   at ALE.ETLBox.DataFlow.DBDestination`1.<InitObjects>b__45_0(TInput[] d) in C:\Users\nallanmu\source\repos\OcelotApiGateway\etlbox-master\ETLBox\src\Toolbox\DataFlow\DBDestination.cs:line 78
   at System.Threading.Tasks.Dataflow.ActionBlock`1.ProcessMessage(Action`1 action, KeyValuePair`2 messageWithId)
   at System.Threading.Tasks.Dataflow.ActionBlock`1.<>c__DisplayClass6_0.<.ctor>b__0(KeyValuePair`2 messageWithId)
   at System.Threading.Tasks.Dataflow.Internal.TargetCore`1.ProcessMessagesLoopCore()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()